### PR TITLE
Split rows into multiple objects with stream({multiple: true})

### DIFF
--- a/test/spec.js
+++ b/test/spec.js
@@ -140,3 +140,31 @@ describe('fof.stream(x, {filter: expression})', function() {
   });
 
 });
+
+describe('fof.stream(x, {multiple: true})', function() {
+
+  var years = [2001, 2002, 2003];
+  it('works', function() {
+    testStream(
+      [
+        {2001: 1, 2002: 2, 2003: 3},
+        {2001: 2, 2002: 1, 2003: 0}
+      ],
+      function(d) {
+        return years.map(function(y) {
+          return {year: y, data: d};
+        });
+      },
+      {multiple: true},
+      [
+        {year: 2001, data: 1},
+        {year: 2002, data: 2},
+        {year: 2003, data: 3},
+        {year: 2001, data: 2},
+        {year: 2002, data: 1},
+        {year: 2003, data: 0}
+      ]
+    );
+  });
+
+});


### PR DESCRIPTION
This adds support for a `multiple: true` option to `fof.stream()`, which allows you to return an array from your transform and have each element of the array output in the resulting object stream, essentially "flattening" the output. This is useful for normalizing tabular data that has columns that you would like to express as separate rows, e.g.

| Name | 2001 | 2002 | 2003 |
| :-- | --: | --: | --: |
| Foo | 4 | 6 | 10 |
| Bar | 8 | 2 | 6 |

You could transform this data with:

``` js
var years = [2001, 2002, 2003];
var transform = function(d) {
  return years.map(function(year) {
    return {
      name: d.Name,
      year: year,
      count: d[year]
    };
  });
};

var tito = require('tito');
var fof = require('fof');
process.stdin
  .pipe(tito.formats.createReadStream('tsv'))
  .pipe(fof.stream(transform, {multiple: true})
  .pipe(tito.formats.createWriteStream('tsv'))
  .pipe(process.stdout);
```

The output would then look like:

| name | year | count |
| :-- | --: | --: |
| Foo | 2001 | 4 |
| Foo | 2002 | 6 |
| Foo | 2003 | 10 |
| Bar | 2001 | 8 |
| Bar | 2002 | 2 |
| Bar | 2003 | 6 |
